### PR TITLE
Template rendering fails when using an undefined variable

### DIFF
--- a/_tests/broken-template-missing-var.yml
+++ b/_tests/broken-template-missing-var.yml
@@ -1,0 +1,2 @@
+---
+foo: {{ .Orbit.missing }}

--- a/app/generator/generator.go
+++ b/app/generator/generator.go
@@ -67,6 +67,8 @@ func (g *OrbitGenerator) Execute() (bytes.Buffer, error) {
 		return data, OrbitError.NewOrbitErrorf("unable to parse the template file %s. Details:\n%s", g.context.TemplateFilePath, err)
 	}
 
+	tmpl.Option("missingkey=error")
+
 	orbitData := &orbitData{
 		Orbit: g.context.Payload,
 	}

--- a/app/generator/generator_test.go
+++ b/app/generator/generator_test.go
@@ -34,6 +34,18 @@ func TestExecute(t *testing.T) {
 	}
 }
 
+func TestExecuteMissingVariableError(t *testing.T) {
+	dataSourceFilePath, _ := filepath.Abs("../../_tests/data-source.yml")
+
+	// case 1: uses a broken data-driven template.
+	brokenTemplateFilePath, _ := filepath.Abs("../../_tests/broken-template-missing-var.yml")
+	ctx, _ := context.NewOrbitContext(brokenTemplateFilePath, "Values,"+dataSourceFilePath)
+	g := NewOrbitGenerator(ctx)
+	if _, err := g.Execute(); err == nil {
+		t.Errorf("OrbitGenerator should not have been able to render the data-driven template %s", brokenTemplateFilePath)
+	}
+}
+
 // Tests if flushing from raw data source works as expected.
 func TestFlushFromRawDataSource(t *testing.T) {
 	templateFilePath, _ := filepath.Abs("../../_tests/template-raw.yml")


### PR DESCRIPTION
### Summary

Rendering fails when using an undefined variable.
Previous implementation was replacing the value with `<no value>`.
For more information, see https://devdocs.io/go/text/template/index#Template.Option

### Closing issues

Fixes #25

### Checklist

- [x] Have you fmt your code locally prior to submission (`orbit run fmt`)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`orbit run ci`)?
- [x] I have squashed any insignificant commits
