### PR TITLE
adding verbose flag

### DIFF
--- a/app/generator/funcmap.go
+++ b/app/generator/funcmap.go
@@ -19,12 +19,12 @@ func getOS() string {
 }
 
 /*
-isInfo returns true if the logs are set to info level.
+isVerbose returns true if the logs are set to info level.
 
 This function is available in
-a data-driven template by using "info".
+a data-driven template by using "verbose".
 */
-func isInfo() bool {
+func isVerbose() bool {
 	return logger.GetLevel() == logrus.InfoLevel
 }
 

--- a/app/generator/funcmap.go
+++ b/app/generator/funcmap.go
@@ -19,7 +19,7 @@ func getOS() string {
 }
 
 /*
-isInfo returns true if the info flag has been given.
+isInfo returns true if the logs are set to info level.
 
 This function is available in
 a data-driven template by using "info".
@@ -29,7 +29,7 @@ func isInfo() bool {
 }
 
 /*
-isDebug returns true if the debug flag has been given.
+isDebug returns true if the logs are set to debug level.
 
 This function is available in
 a data-driven template by using "debug".

--- a/app/generator/funcmap.go
+++ b/app/generator/funcmap.go
@@ -4,6 +4,8 @@ import (
 	"runtime"
 
 	"github.com/gulien/orbit/app/logger"
+
+	"github.com/sirupsen/logrus"
 )
 
 /*
@@ -17,11 +19,21 @@ func getOS() string {
 }
 
 /*
-getOS returns the OS name at runtime.
+isInfo returns true if the info flag has been given.
+
+This function is available in
+a data-driven template by using "info".
+*/
+func isInfo() bool {
+	return logger.GetLevel() == logrus.InfoLevel
+}
+
+/*
+isDebug returns true if the debug flag has been given.
 
 This function is available in
 a data-driven template by using "debug".
 */
 func isDebug() bool {
-	return !logger.IsSilent()
+	return logger.GetLevel() == logrus.DebugLevel
 }

--- a/app/generator/funcmap_test.go
+++ b/app/generator/funcmap_test.go
@@ -13,8 +13,8 @@ func TestGetOS(t *testing.T) {
 }
 
 // A dumb test to improve code coverage.
-func TestIsInfo(t *testing.T) {
-	if isInfo() != false {
+func TesIsVerbose(t *testing.T) {
+	if isVerbose() != false {
 		t.Error("Dumb test should have been successful!")
 	}
 }

--- a/app/generator/funcmap_test.go
+++ b/app/generator/funcmap_test.go
@@ -3,8 +3,6 @@ package generator
 import (
 	"runtime"
 	"testing"
-
-	"github.com/gulien/orbit/app/logger"
 )
 
 // A dumb test to improve code coverage.
@@ -15,8 +13,15 @@ func TestGetOS(t *testing.T) {
 }
 
 // A dumb test to improve code coverage.
+func TestIsInfo(t *testing.T) {
+	if isInfo() != false {
+		t.Error("Dumb test should have been successful!")
+	}
+}
+
+// A dumb test to improve code coverage.
 func TestIsDebug(t *testing.T) {
-	if isDebug() != !logger.IsSilent() {
+	if isDebug() != false {
 		t.Error("Dumb test should have been successful!")
 	}
 }

--- a/app/generator/generator.go
+++ b/app/generator/generator.go
@@ -42,7 +42,7 @@ type (
 func NewOrbitGenerator(context *context.OrbitContext) *OrbitGenerator {
 	funcMap := sprig.TxtFuncMap()
 	funcMap["os"] = getOS
-	funcMap["info"] = isInfo
+	funcMap["verbose"] = isVerbose
 	funcMap["debug"] = isDebug
 
 	g := &OrbitGenerator{

--- a/app/generator/generator.go
+++ b/app/generator/generator.go
@@ -42,6 +42,7 @@ type (
 func NewOrbitGenerator(context *context.OrbitContext) *OrbitGenerator {
 	funcMap := sprig.TxtFuncMap()
 	funcMap["os"] = getOS
+	funcMap["info"] = isInfo
 	funcMap["debug"] = isDebug
 
 	g := &OrbitGenerator{
@@ -115,13 +116,13 @@ func flushToFile(outputPath string, data bytes.Buffer) error {
 		return OrbitError.NewOrbitErrorf("unable to flushToFile into the output file %s. Details:\n%s", outputPath, err)
 	}
 
-	logger.Debugf("output file %s has been created", outputPath)
+	logger.Infof("output file %s has been created", outputPath)
 
 	return nil
 }
 
 // flushToStdout writes bytes to Stdout.
 func flushToStdout(data bytes.Buffer) {
-	logger.Debugf("no output file given, printing the result to Stdout")
+	logger.Infof("no output file given, printing the result to Stdout")
 	fmt.Println(string(data.Bytes()))
 }

--- a/app/logger/logger.go
+++ b/app/logger/logger.go
@@ -21,7 +21,7 @@ type orbitLogger struct {
 func newOrbitLogger() *orbitLogger {
 	l := logrus.New()
 	l.Out = os.Stdout
-	l.Level = logrus.PanicLevel
+	l.Level = logrus.ErrorLevel
 
 	return &orbitLogger{
 		logger: l,

--- a/app/root.go
+++ b/app/root.go
@@ -16,8 +16,8 @@ var (
 	// Value format: key,path;key,path;key,data...
 	payload string
 
-	// info enables info logs if true.
-	info bool
+	// verbose enables info logs if true.
+	verbose bool
 
 	// debug enables debug logs if true.
 	debug bool
@@ -29,7 +29,7 @@ var (
 		Long:          "A cross-platform task runner for executing commands and generating files from templates.",
 		SilenceErrors: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if info {
+			if verbose {
 				logger.SetLevel(logrus.InfoLevel)
 			}
 
@@ -43,6 +43,6 @@ var (
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&templateFilePath, "file", "f", "", "specify the path of a data-driven template")
 	RootCmd.PersistentFlags().StringVarP(&payload, "payload", "p", "", "specify a map of YAML files, TOML files, JSON files, .env files and raw data")
-	RootCmd.PersistentFlags().BoolVarP(&info, "info", "i", false, "set logging to info level")
+	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "set logging to info level")
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "set logging to debug level")
 }

--- a/app/root.go
+++ b/app/root.go
@@ -4,6 +4,7 @@ package app
 import (
 	"github.com/gulien/orbit/app/logger"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +16,10 @@ var (
 	// Value format: key,path;key,path;key,data...
 	payload string
 
-	// debug enables logging if true.
+	// info enables info logs if true.
+	info bool
+
+	// debug enables debug logs if true.
 	debug bool
 
 	// RootCmd is the instance of the root of all commands.
@@ -25,8 +29,12 @@ var (
 		Long:          "A cross-platform task runner for executing commands and generating files from templates.",
 		SilenceErrors: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if !debug {
-				logger.Mute()
+			if info {
+				logger.SetLevel(logrus.InfoLevel)
+			}
+
+			if debug {
+				logger.SetLevel(logrus.DebugLevel)
 			}
 		},
 	}
@@ -35,5 +43,6 @@ var (
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&templateFilePath, "file", "f", "", "specify the path of a data-driven template")
 	RootCmd.PersistentFlags().StringVarP(&payload, "payload", "p", "", "specify a map of YAML files, TOML files, JSON files, .env files and raw data")
-	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "display a detailed output")
+	RootCmd.PersistentFlags().BoolVarP(&info, "info", "i", false, "display info logs")
+	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "display debug logs")
 }

--- a/app/root.go
+++ b/app/root.go
@@ -43,6 +43,6 @@ var (
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&templateFilePath, "file", "f", "", "specify the path of a data-driven template")
 	RootCmd.PersistentFlags().StringVarP(&payload, "payload", "p", "", "specify a map of YAML files, TOML files, JSON files, .env files and raw data")
-	RootCmd.PersistentFlags().BoolVarP(&info, "info", "i", false, "set logs to info level")
-	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "set logs to debug level")
+	RootCmd.PersistentFlags().BoolVarP(&info, "info", "i", false, "set logging to info level")
+	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "set logging to debug level")
 }

--- a/app/root.go
+++ b/app/root.go
@@ -43,6 +43,6 @@ var (
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&templateFilePath, "file", "f", "", "specify the path of a data-driven template")
 	RootCmd.PersistentFlags().StringVarP(&payload, "payload", "p", "", "specify a map of YAML files, TOML files, JSON files, .env files and raw data")
-	RootCmd.PersistentFlags().BoolVarP(&info, "info", "i", false, "display info logs")
-	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "display debug logs")
+	RootCmd.PersistentFlags().BoolVarP(&info, "info", "i", false, "set logs to info level")
+	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "set logs to debug level")
 }

--- a/app/runner/runner.go
+++ b/app/runner/runner.go
@@ -130,7 +130,7 @@ func (r *OrbitRunner) Run(names ...string) error {
 
 // run executes the stack of commands from the given task.
 func (r *OrbitRunner) run(task *orbitTask) error {
-	logger.Debugf("running task %s", task.Use)
+	logger.Infof("running task %s: %s", task.Use, task.Short)
 
 	for _, cmd := range task.Run {
 
@@ -141,7 +141,7 @@ func (r *OrbitRunner) run(task *orbitTask) error {
 			e = exec.Command(os.Getenv(defaultPosixShellEnvVariable), "-c", cmd)
 		}
 
-		logger.Debugf("executing command %s", e.Args)
+		logger.Infof("executing command %s", e.Args)
 
 		e.Stdout = os.Stdout
 		e.Stderr = os.Stderr

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 	"os"
 
 	"github.com/gulien/orbit/app"
-	OrbitError "github.com/gulien/orbit/app/error"
 	"github.com/gulien/orbit/app/logger"
 	OrbitVersion "github.com/gulien/orbit/app/version"
 )
@@ -34,12 +33,7 @@ func main() {
 	OrbitVersion.Current = version
 
 	if err := app.RootCmd.Execute(); err != nil {
-		if orbitError, ok := err.(*OrbitError.OrbitError); ok {
-			logger.NotifyOrbitError(orbitError)
-		} else {
-			logger.Error(err)
-		}
-
+		logger.Error(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Adds `-v--verbose` flag which displays less logs than the `-d --debug` flag.

Example when running a task:

```bash
INFO[0000] running task fmt: Runs go fmt ./...
INFO[0000] executing command [/bin/zsh -c go fmt ./...]
```

Feature request from #29