### PR TITLE
adding the possibility to call others tasks from a task

### DIFF
--- a/_tests/orbit.yml
+++ b/_tests/orbit.yml
@@ -1,23 +1,31 @@
 tasks:
   - use: "explorer"
     run:
-      - dep status
+      - echo "I am explorer task"
   - use: "sputnik"
     private: true
     run:
-      - dep status
+      - echo "I am sputnik task"
   - use: "challenger"
     run:
-      - faildep status
+      - failecho "I am challenger task"
   - use: "zuma"
     shell: nope.sh
     run:
-      - dep status
+      - echo "I am zuma task"
   - use: "falcon"
     shell: bash -c
     run:
-      - dep status
+      - echo "I am falcon task"
   - use: "ariane"
     shell: ls
     run:
       - -l
+  - use: "new shepard"
+    run:
+      - echo "I am new shepard task"
+      - {{ run "explorer" "sputnik" }}
+  - use: "new glenn"
+    run:
+    - echo "I am new glenn task"
+    - {{ run "vulcan" }}

--- a/app/generator/funcmap.go
+++ b/app/generator/funcmap.go
@@ -1,7 +1,9 @@
 package generator
 
 import (
+	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/gulien/orbit/app/logger"
 
@@ -36,4 +38,15 @@ a data-driven template by using "debug".
 */
 func isDebug() bool {
 	return logger.GetLevel() == logrus.DebugLevel
+}
+
+/*
+run returns a string which will be parsed by a regex pattern
+in our runner.
+
+This function is available in
+a data-driven template by using "run".
+*/
+func run(tasks ...string) string {
+	return fmt.Sprintf("run@%s", strings.Join(tasks, ","))
 }

--- a/app/generator/funcmap_test.go
+++ b/app/generator/funcmap_test.go
@@ -25,3 +25,10 @@ func TestIsDebug(t *testing.T) {
 		t.Error("Dumb test should have been successful!")
 	}
 }
+
+// Tests run function to check if it returns a well-formed string.
+func TestRun(t *testing.T) {
+	if run("explorer", "falcon") != "run@explorer,falcon" {
+		t.Error("String returned by run function is malformated!")
+	}
+}

--- a/app/generator/generator.go
+++ b/app/generator/generator.go
@@ -44,6 +44,7 @@ func NewOrbitGenerator(context *context.OrbitContext) *OrbitGenerator {
 	funcMap["os"] = getOS
 	funcMap["verbose"] = isVerbose
 	funcMap["debug"] = isDebug
+	funcMap["run"] = run
 
 	g := &OrbitGenerator{
 		context: context,

--- a/app/runner/runner_test.go
+++ b/app/runner/runner_test.go
@@ -83,4 +83,13 @@ func TestRun(t *testing.T) {
 		t.Error("Custom shell task should have been run!")
 	}
 
+	// case 8: uses a task which calls others tasks
+	if err := r.Run("new shepard"); err != nil {
+		t.Error("Task calling others tasks should have been run!")
+	}
+
+	// case 9: uses a task which calls a non existing task.
+	if err := r.Run("new glenn"); err == nil {
+		t.Error("Task calling another task should not have been run!")
+	}
 }


### PR DESCRIPTION
This PR enable calling others tasks from a task within the same context.

`orbit.yml`:

```yaml
tasks:
  - use: app
  - run:
      - {{ run "render" "upload" }}
      - echo "done!"

  - use: render
  - run:
      - cmd

  - use: upload
  - run:
      - cmd
```

Fixes #24 